### PR TITLE
Changing to dest=2014 in docfx.json, per Yufei Huang.

### DIFF
--- a/docs-archive-a/docfx.json
+++ b/docs-archive-a/docfx.json
@@ -17,7 +17,7 @@
           "LICENSE-CODE"
         ],
         "src": "2014",
-        "dest": "."
+        "dest": "./2014"
       }
     ],
     "resource": [


### PR DESCRIPTION
Changing to dest=2014 in docfx.json, per Yufei Huang.

This PR aims to update the release-* branch in Khairun Jamal's fork of primary repo = 'MicrosoftDocssql-docs-archive-pr'. This PR does Not aim to directly update the primary repo (that should happen later, when Khairun merges her PR 2.

This dest update in docfx.json is intended to add the node '2014/' to the review.docs Https URL. The outcome should look like:

- `https://docs.microsoft.com/previous-versions/sql/2014/blah-blah` 

GeneMi ( = MightyPen )
. .
